### PR TITLE
feat: presentation 모듈 추가

### DIFF
--- a/book-talk-be/api/build.gradle.kts
+++ b/book-talk-be/api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("io.github.oshai:kotlin-logging-jvm:6.0.3")
+    implementation("com.github.java-json-tools:json-patch:1.13")
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateController.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateController.kt
@@ -21,7 +21,7 @@ class DebateController(
         debateService.create(request, authAccount)
     }
 
-    /** 토론 조회 */
+    /** 토론 단건 조회 */
     @GetMapping("/debates/{id}")
     fun findOne(@PathVariable id: String, authAccount: AuthAccount): ApiResult<FindOneResponse> {
         return debateService.findOne(id).toResult()

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateService.kt
@@ -14,6 +14,7 @@ class DebateService(
     private val debateRepository: DebateRepository,
     private val debateMemberRepository: DebateMemberRepository,
     private val appConfigService: AppConfigService,
+    private val presentationRepository: PresentationRepository,
 ) {
     @Transactional
     fun create(request: CreateRequest, authAccount: AuthAccount) {
@@ -29,8 +30,11 @@ class DebateService(
     }
 
     fun findOne(id: String): FindOneResponse {
-        return debateRepository.findByIdOrNull(id)?.toResponse()
-            ?: httpBadRequest("존재하지 않는 토론방입니다.")
+        val debate = debateRepository.findByIdOrNull(id) ?: httpBadRequest("존재하지 않는 토론방입니다.")
+        val members = debateMemberRepository.findAllByDebateOrderByCreatedAtAsc(debate)
+        val presentations = presentationRepository.findAllByDebateOrderByCreatedAtAsc(debate)
+
+        return debate.toResponse(members, presentations)
     }
 
     fun join(request: JoinRequest, authAccount: AuthAccount) {

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Converters.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Converters.kt
@@ -2,6 +2,8 @@ package kr.co.booktalk.domain.debate
 
 import kr.co.booktalk.domain.AccountEntity
 import kr.co.booktalk.domain.DebateEntity
+import kr.co.booktalk.domain.DebateMemberEntity
+import kr.co.booktalk.domain.PresentationEntity
 
 fun CreateRequest.toEntity(host: AccountEntity): DebateEntity {
     return DebateEntity(
@@ -14,9 +16,14 @@ fun CreateRequest.toEntity(host: AccountEntity): DebateEntity {
     )
 }
 
-fun DebateEntity.toResponse(): FindOneResponse {
+fun DebateEntity.toResponse(
+    members: List<DebateMemberEntity>,
+    presentations: List<PresentationEntity>
+): FindOneResponse {
     return FindOneResponse(
         id = id.toString(),
+        members = members.map { FindOneResponse.MemberInfo(it.account.id!!, it.role) },
+        presentations = presentations.map { FindOneResponse.PresentationInfo(it.id!!, it.account.id!!) },
         bookImageUrl = bookImageUrl,
         topic = topic,
         description = description,

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Responses.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Responses.kt
@@ -1,9 +1,12 @@
 package kr.co.booktalk.domain.debate
 
+import kr.co.booktalk.domain.DebateMemberRole
 import java.time.Instant
 
 data class FindOneResponse(
     val id: String,
+    val members: List<MemberInfo>,
+    val presentations: List<PresentationInfo>,
     val bookImageUrl: String,
     val topic: String,
     val description: String? = null,
@@ -13,4 +16,14 @@ data class FindOneResponse(
     val createdAt: Instant,
     val updatedAt: Instant,
     val archivedAt: Instant? = null,
-)
+) {
+    data class MemberInfo(
+        val id: String,
+        val role: DebateMemberRole,
+    )
+
+    data class PresentationInfo(
+        val id: String,
+        val accountId: String,
+    )
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Validators.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Validators.kt
@@ -18,6 +18,12 @@ fun JoinRequest.validate() {
 fun DebateEntity.validateJoinable(joinDebateDeadlineSeconds: Long): DebateEntity {
     val now = Instant.now()
     require(now.isBefore(startedAt.minusSeconds(joinDebateDeadlineSeconds))) { "토론 참여 가능 시간이 아닙니다." }
+    this.validateActive()
+
+    return this
+}
+
+fun DebateEntity.validateActive(): DebateEntity {
     require(closedAt == null) { "종료된 토론입니다." }
 
     return this

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/PresentationController.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/PresentationController.kt
@@ -1,0 +1,31 @@
+package kr.co.booktalk.domain.presentation
+
+import com.github.fge.jsonpatch.JsonPatch
+import kr.co.booktalk.ApiResult
+import kr.co.booktalk.domain.auth.AuthAccount
+import kr.co.booktalk.toResult
+import org.springframework.web.bind.annotation.*
+
+@RestController
+class PresentationController(
+    private val presentationService: PresentationService
+) {
+    /** 발표 페이지 단건 조회 */
+    @GetMapping("/presentations/{id}")
+    fun findOne(@PathVariable id: String, authAccount: AuthAccount): ApiResult<FindOneResponse> {
+        return presentationService.findOne(id).toResult()
+    }
+
+    /** 발표 페이지 최초 생성 */
+    @PostMapping("/presentations")
+    fun init(@RequestBody request: CreateRequest, authAccount: AuthAccount) {
+        request.validate()
+        presentationService.init(request, authAccount)
+    }
+
+    /** 발표 페이지 내용 수정 */
+    @PatchMapping(value = ["/presentations/{id}/content"], consumes = ["application/json-patch+json"])
+    fun patchContent(@PathVariable id: String, @RequestBody patch: JsonPatch, authAccount: AuthAccount) {
+        presentationService.patchContent(id, patch, authAccount)
+    }
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/PresentationService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/PresentationService.kt
@@ -1,0 +1,60 @@
+package kr.co.booktalk.domain.presentation
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.github.fge.jsonpatch.JsonPatch
+import kr.co.booktalk.domain.AccountRepository
+import kr.co.booktalk.domain.DebateRepository
+import kr.co.booktalk.domain.PresentationEntity
+import kr.co.booktalk.domain.PresentationRepository
+import kr.co.booktalk.domain.auth.AuthAccount
+import kr.co.booktalk.domain.debate.validateActive
+import kr.co.booktalk.httpBadRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PresentationService(
+    private val accountRepository: AccountRepository,
+    private val debateRepository: DebateRepository,
+    private val presentationRepository: PresentationRepository,
+    private val objectMapper: ObjectMapper
+) {
+    fun findOne(id: String): FindOneResponse {
+        return presentationRepository.findByIdOrNull(id)?.toResponse() ?: httpBadRequest("존재하지 않는 프레젠테이션입니다.")
+    }
+
+    fun init(request: CreateRequest, authAccount: AuthAccount) {
+        val account = accountRepository.findByIdOrNull(authAccount.id)
+            ?: httpBadRequest("존재하지 않는 사용자입니다.")
+        val debate = debateRepository.findByIdOrNull(request.debateId)
+            ?.validateActive()
+            ?: httpBadRequest("존재하지 않는 토론입니다.")
+
+        presentationRepository.save(PresentationEntity(debate, account, "[]"))
+    }
+
+    @Transactional
+    fun patchContent(id: String, patch: JsonPatch, authAccount: AuthAccount) {
+        accountRepository.findByIdOrNull(authAccount.id)
+            ?: httpBadRequest("존재하지 않는 사용자입니다.")
+        val presentation = presentationRepository.findByIdOrNull(id)
+            ?.validateUpdatable(authAccount)
+            ?: httpBadRequest("존재하지 않는 프레젠테이션입니다.")
+
+        val currentNode: JsonNode = try {
+            objectMapper.readTree(presentation.content)
+        } catch (e: Exception) {
+            httpBadRequest("기존 content가 유효한 JSON 형식이 아닙니다.", e)
+        }
+
+        val patchedNode: JsonNode = try {
+            patch.apply(currentNode)
+        } catch (e: Exception) {
+            httpBadRequest("JSON Patch 적용 실패: ${e.message}", e)
+        }
+
+        presentation.content = objectMapper.writeValueAsString(patchedNode)
+    }
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Converters.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Converters.kt
@@ -1,0 +1,12 @@
+package kr.co.booktalk.domain.presentation
+
+import kr.co.booktalk.domain.PresentationEntity
+
+fun PresentationEntity.toResponse(): FindOneResponse {
+    return FindOneResponse(
+        id = id!!,
+        accountId = account.id!!,
+        debateId = debate.id!!,
+        content = content
+    )
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Requests.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Requests.kt
@@ -1,0 +1,5 @@
+package kr.co.booktalk.domain.presentation
+
+data class CreateRequest(
+    val debateId: String,
+)

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Responses.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Responses.kt
@@ -1,0 +1,8 @@
+package kr.co.booktalk.domain.presentation
+
+data class FindOneResponse(
+    val id: String,
+    val accountId: String,
+    val debateId: String,
+    val content: String
+)

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Validators.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/presentation/_Validators.kt
@@ -1,0 +1,14 @@
+package kr.co.booktalk.domain.presentation
+
+import kr.co.booktalk.domain.PresentationEntity
+import kr.co.booktalk.domain.auth.AuthAccount
+
+fun CreateRequest.validate() {
+    require(debateId.isNotBlank()) { "debateId는 필수입니다." }
+}
+
+fun PresentationEntity.validateUpdatable(authAccount: AuthAccount): PresentationEntity {
+    require(account.id == authAccount.id) { "자신의 프로젠테이션만 수정 가능합니다." }
+
+    return this
+}

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateMember.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateMember.kt
@@ -22,7 +22,7 @@ class DebateMemberEntity(
     val account: AccountEntity,
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
+    @Column(name = "role", nullable = false)
     val role: DebateMemberRole
 ) : AuditableLongIdEntity()
 
@@ -36,4 +36,6 @@ interface DebateMemberRepository : JpaRepository<DebateMemberEntity, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select count(m) from DebateMemberEntity m where m.debate = :debate")
     fun countByDebateForUpdate(debate: DebateEntity): Int
+
+    fun findAllByDebateOrderByCreatedAtAsc(debate: DebateEntity): List<DebateMemberEntity>
 }

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/Presentation.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/Presentation.kt
@@ -1,0 +1,30 @@
+package kr.co.booktalk.domain
+
+import jakarta.persistence.*
+import kr.co.booktalk.AuditableUuidEntity
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+@Entity
+@Table(name = "presentation")
+@EntityListeners(AuditingEntityListener::class)
+class PresentationEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "debate_id", nullable = false)
+    val debate: DebateEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: AccountEntity,
+
+    @Column(nullable = false)
+    var content: String,
+) : AuditableUuidEntity()
+
+@Transactional(readOnly = true)
+@Repository
+interface PresentationRepository : JpaRepository<PresentationEntity, String> {
+    fun findAllByDebateOrderByCreatedAtAsc(debate: DebateEntity): List<PresentationEntity>
+}

--- a/book-talk-be/data/src/main/resources/schema/4.presentation.sql
+++ b/book-talk-be/data/src/main/resources/schema/4.presentation.sql
@@ -1,0 +1,11 @@
+create table if not exists presentation
+(
+    id          uuid           not null primary key,
+    debate_id   uuid           not null,
+    account_id  uuid           not null,
+    content     varchar(30000) not null,
+
+    created_at  timestamp      not null,
+    updated_at  timestamp      not null,
+    archived_at timestamp      null
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 프레젠테이션 조회/생성/내용 수정용 API 및 관련 응답 타입 추가
  - 토론 상세 응답에 참여자 목록과 프레젠테이션 목록 포함

- Bug Fixes
  - 오류 처리 개선: 잘못된 요청은 400, 서버 오류는 500으로 명확 응답 및 예외 로깅 강화
  - 토론 참가 가능 여부에 종료 상태 검증 추가
  - 본인 프레젠테이션만 수정 가능하도록 검증 강화

- Chores
  - JSON Patch 관련 런타임 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->