### PR TITLE
feat: add debate round logic

### DIFF
--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/ApiException.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/ApiException.kt
@@ -71,6 +71,14 @@ fun httpUnauthenticated(message: String, cause: Throwable? = null, errorCode: Er
         errorCode = errorCode?.name
     )
 
+fun httpForbidden(message: String, cause: Throwable? = null, errorCode: ErrorCode? = null): Nothing =
+    throw HttpException(
+        status = HttpStatus.FORBIDDEN,
+        responseMessage = message,
+        cause = cause,
+        errorCode = errorCode?.name
+    )
+
 fun httpInternalServerError(cause: Throwable? = null, errorCode: ErrorCode? = null): Nothing =
     throw HttpException(
         status = HttpStatus.INTERNAL_SERVER_ERROR,

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/cache/AppConfigService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/cache/AppConfigService.kt
@@ -26,6 +26,11 @@ class AppConfigService(
         return findByKey("maxDebateMemberCnt").toLong()
     }
 
+    /** 토론 라운드 발언자 발언 시간(초) */
+    fun debateRoundSpeakerSeconds(): Long {
+        return findByKey("debateRoundSpeakerSeconds").toLong()
+    }
+
     fun findByKey(key: String): String {
         val now = Instant.now()
         val cachedEntry = cache[key]

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateController.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateController.kt
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.*
 @RestController
 class DebateController(
     private val debateService: DebateService,
-    private val appConfigService: AppConfigService
+    private val debateRoundService: DebateRoundService,
+    private val appConfigService: AppConfigService,
+    private val debateRoundSpeakerService: DebateRoundSpeakerService
 ) {
     /** 토론 생성 */
     @PostMapping("/debates")
@@ -32,5 +34,33 @@ class DebateController(
     fun join(@RequestBody request: JoinRequest, authAccount: AuthAccount) {
         request.validate()
         debateService.join(request, authAccount)
+    }
+
+    /** 방장: 토론 라운드 생성(시작) */
+    @PostMapping("/debates/round")
+    fun createRound(@RequestBody request: CreateRoundRequest, authAccount: AuthAccount) {
+        request.validate()
+        debateRoundService.create(request, authAccount)
+    }
+
+    /** 방장: 토론 라운드 변경 */
+    @PatchMapping("/debates/round")
+    fun patchRound(@RequestBody request: PatchRoundRequest, authAccount: AuthAccount) {
+        request.validate()
+        debateRoundService.patch(request, authAccount)
+    }
+
+    /** 발언자 생성 */
+    @PostMapping("/debates/round/speakers")
+    fun createRoundSpeaker(@RequestBody request: CreateRoundSpeakerRequest, authAccount: AuthAccount) {
+        request.validate()
+        debateRoundSpeakerService.create(request)
+    }
+
+    /** 발언자 업데이트 */
+    @PatchMapping("/debates/round/speakers")
+    fun patchRoundSpeaker(@RequestBody request: PatchRoundSpeakerRequest, authAccount: AuthAccount) {
+        request.validate()
+        debateRoundSpeakerService.patch(request)
     }
 }

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateRoundService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateRoundService.kt
@@ -1,0 +1,49 @@
+package kr.co.booktalk.domain.debate
+
+import kr.co.booktalk.domain.*
+import kr.co.booktalk.domain.auth.AuthAccount
+import kr.co.booktalk.httpBadRequest
+import kr.co.booktalk.httpForbidden
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class DebateRoundService(
+    private val debateRepository: DebateRepository,
+    private val debateMemberRepository: DebateMemberRepository,
+    private val accountRepository: AccountRepository,
+    private val debateRoundRepository: DebateRoundRepository,
+) {
+    fun create(request: CreateRoundRequest, authAccount: AuthAccount) {
+        if (!isHost(request.debateId, authAccount.id)) httpForbidden("토론 방장이 아닙니다.")
+        val debate = debateRepository.findByIdOrNull(request.debateId) ?: httpBadRequest("존재하지 않는 토론입니다.")
+        val nextSpeaker = accountRepository.findByIdOrNull(request.nextSpeakerId) ?: httpBadRequest("존재하지 않는 계정입니다.")
+        if (!debateMemberRepository.existsByDebateAndAccount(debate, nextSpeaker)) httpBadRequest("발언자가 토론 멤버가 아닙니다.")
+
+        debateRoundRepository.save(request.toEntity(debate, nextSpeaker))
+    }
+
+    @Transactional
+    fun patch(request: PatchRoundRequest, authAccount: AuthAccount) {
+        val debateRound = debateRoundRepository.findByIdOrNull(request.debateRoundId)
+            ?: httpBadRequest("존재하지 않는 톡서 토론 라운드입니다.")
+        if (!isHost(debateRound.debate.id!!, authAccount.id)) httpForbidden("토론 방장이 아닙니다.")
+        request.nextSpeakerId?.let {
+            debateRound.nextSpeaker = accountRepository.findByIdOrNull(it) ?: httpBadRequest("존재하지 않는 계정입니다.")
+        }
+        request.ended?.takeIf { it }?.let { debateRound.endedAt = Instant.now() }
+    }
+
+    /** 토론 방장 검증 */
+    private fun isHost(debateId: String, accountId: String): Boolean {
+        return debateMemberRepository.existsByDebateIdAndAccountIdAndRole(
+            debateId,
+            accountId,
+            DebateMemberRole.HOST
+        )
+    }
+
+
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateRoundSpeakerService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/DebateRoundSpeakerService.kt
@@ -1,0 +1,48 @@
+package kr.co.booktalk.domain.debate
+
+import kr.co.booktalk.cache.AppConfigService
+import kr.co.booktalk.domain.*
+import kr.co.booktalk.httpBadRequest
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class DebateRoundSpeakerService(
+    private val accountRepository: AccountRepository,
+    private val debateRoundSpeakerRepository: DebateRoundSpeakerRepository,
+    private val debateRoundRepository: DebateRoundRepository,
+    private val appConfigService: AppConfigService,
+    private val debateMemberRepository: DebateMemberRepository
+) {
+    fun create(request: CreateRoundSpeakerRequest) {
+        val debateRound = debateRoundRepository.findByIdOrNull(request.debateRoundId)
+            ?: httpBadRequest("존재하지 않는 토론 라운드입니다.")
+        val speaker = accountRepository.findByIdOrNull(request.nextSpeakerId)
+            ?: httpBadRequest("존재하지 않는 계정입니다.")
+        if (!debateMemberRepository.existsByDebateAndAccount(debateRound.debate, speaker))
+            httpBadRequest("발언자가 토론 멤버가 아닙니다.")
+
+        debateRoundSpeakerRepository.save(
+            DebateRoundSpeakerEntity(
+                account = speaker,
+                debateRound = debateRound,
+                endedAt = Instant.now().plusSeconds(appConfigService.debateRoundSpeakerSeconds())
+            )
+        )
+    }
+
+    @Transactional
+    fun patch(request: PatchRoundSpeakerRequest) {
+        val speaker = debateRoundSpeakerRepository.findByIdOrNull(request.debateRoundSpeakerId)
+            ?: httpBadRequest("존재하지 않는 토론 발언자입니다.")
+
+        request.extension?.takeIf { it }?.let {
+            speaker.endedAt = speaker.endedAt.plusSeconds(appConfigService.debateRoundSpeakerSeconds())
+        }
+        request.ended?.takeIf { it }?.let {
+            speaker.endedAt = Instant.now()
+        }
+    }
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Converters.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Converters.kt
@@ -1,9 +1,6 @@
 package kr.co.booktalk.domain.debate
 
-import kr.co.booktalk.domain.AccountEntity
-import kr.co.booktalk.domain.DebateEntity
-import kr.co.booktalk.domain.DebateMemberEntity
-import kr.co.booktalk.domain.PresentationEntity
+import kr.co.booktalk.domain.*
 
 fun CreateRequest.toEntity(host: AccountEntity): DebateEntity {
     return DebateEntity(
@@ -18,12 +15,15 @@ fun CreateRequest.toEntity(host: AccountEntity): DebateEntity {
 
 fun DebateEntity.toResponse(
     members: List<DebateMemberEntity>,
-    presentations: List<PresentationEntity>
+    presentations: List<PresentationEntity>,
+    currentRound: DebateRoundEntity? = null,
+    currentSpeakerId: String? = null
 ): FindOneResponse {
     return FindOneResponse(
         id = id.toString(),
         members = members.map { FindOneResponse.MemberInfo(it.account.id!!, it.role) },
         presentations = presentations.map { FindOneResponse.PresentationInfo(it.id!!, it.account.id!!) },
+        currentRound = if (currentRound != null && currentSpeakerId != null) currentRound.toRoundInfo(currentSpeakerId) else null,
         bookImageUrl = bookImageUrl,
         topic = topic,
         description = description,
@@ -33,5 +33,24 @@ fun DebateEntity.toResponse(
         createdAt = createdAt,
         updatedAt = updatedAt,
         archivedAt = archivedAt
+    )
+}
+
+fun DebateRoundEntity.toRoundInfo(currentSpeakerId: String): FindOneResponse.RoundInfo {
+    return FindOneResponse.RoundInfo(
+        id = id,
+        type = type,
+        currentSpeakerId = currentSpeakerId,
+        nextSpeakerId = nextSpeaker?.id,
+        createdAt = createdAt,
+        endedAt = endedAt,
+    )
+}
+
+fun CreateRoundRequest.toEntity(debate: DebateEntity, speaker: AccountEntity): DebateRoundEntity {
+    return DebateRoundEntity(
+        type = type,
+        debate = debate,
+        nextSpeaker = speaker
     )
 }

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Requests.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Requests.kt
@@ -1,5 +1,6 @@
 package kr.co.booktalk.domain.debate
 
+import kr.co.booktalk.domain.DebateRoundType
 import java.time.Instant
 
 data class CreateRequest(
@@ -12,4 +13,35 @@ data class CreateRequest(
 
 data class JoinRequest(
     val debateId: String,
+)
+
+data class CreateRoundRequest(
+    val debateId: String,
+    val type: DebateRoundType,
+    val nextSpeakerId: String,
+)
+
+data class PatchRoundRequest(
+    val debateRoundId: Long,
+    /** 다음 발언자 예약 */
+    val nextSpeakerId: String? = null,
+    /** 토론 라운드 종료 */
+    val ended: Boolean? = null,
+)
+
+data class CloseRoundRequest(
+    val debateId: String,
+)
+
+data class CreateRoundSpeakerRequest(
+    val debateRoundId: Long,
+    val nextSpeakerId: String,
+)
+
+data class PatchRoundSpeakerRequest(
+    val debateRoundSpeakerId: Long,
+    /** 발언 시간 증가 */
+    val extension: Boolean? = null,
+    /** 발언 종료 */
+    val ended: Boolean? = null,
 )

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Responses.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Responses.kt
@@ -1,12 +1,14 @@
 package kr.co.booktalk.domain.debate
 
 import kr.co.booktalk.domain.DebateMemberRole
+import kr.co.booktalk.domain.DebateRoundType
 import java.time.Instant
 
 data class FindOneResponse(
     val id: String,
     val members: List<MemberInfo>,
     val presentations: List<PresentationInfo>,
+    val currentRound: RoundInfo? = null,
     val bookImageUrl: String,
     val topic: String,
     val description: String? = null,
@@ -25,5 +27,14 @@ data class FindOneResponse(
     data class PresentationInfo(
         val id: String,
         val accountId: String,
+    )
+
+    data class RoundInfo(
+        val id: Long,
+        val type: DebateRoundType,
+        val currentSpeakerId: String,
+        val nextSpeakerId: String? = null,
+        val createdAt: Instant,
+        val endedAt: Instant? = null,
     )
 }

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Validators.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/debate/_Validators.kt
@@ -28,3 +28,25 @@ fun DebateEntity.validateActive(): DebateEntity {
 
     return this
 }
+
+fun CreateRoundRequest.validate() {
+    require(debateId.isNotBlank()) { "debateId는 필수입니다." }
+    require(nextSpeakerId.isNotBlank()) { "nextSpeakerId는 필수입니다." }
+}
+
+fun PatchRoundRequest.validate() {
+    require(debateRoundId > 0) { "debateRoundId는 필수입니다." }
+}
+
+fun CloseRoundRequest.validate() {
+    require(debateId.isNotBlank()) { "debateId는 필수입니다." }
+}
+
+fun CreateRoundSpeakerRequest.validate() {
+    require(debateRoundId > 0) { "debateRoundId는 필수입니다." }
+    require(nextSpeakerId.isNotBlank()) { "nextSpeakerId는 필수입니다." }
+}
+
+fun PatchRoundSpeakerRequest.validate() {
+    require(debateRoundSpeakerId > 0) { "debateRoundSpeakerId는 필수입니다." }
+}

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/AbstractEntity.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/AbstractEntity.kt
@@ -35,19 +35,11 @@ abstract class AuditableLongIdEntity : AuditableEntity, Persistable<Long> {
     override fun isNew(): Boolean = !::createdAt.isInitialized
 }
 
-@Converter(autoApply = true)
-class UuidToStringConverter : AttributeConverter<UUID, String> {
-    override fun convertToDatabaseColumn(attribute: UUID?): String? = attribute?.toString()
-    override fun convertToEntityAttribute(dbData: String?): UUID? = dbData?.let { UUID.fromString(it) }
-}
-
 @MappedSuperclass
 abstract class AuditableUuidEntity : AuditableEntity, Persistable<String> {
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", columnDefinition = "uuid")
-    @Convert(converter = UuidToStringConverter::class)
-    private var id: String? = null
+    private var id: String? = UUID.randomUUID().toString()
 
     @CreatedDate
     @Column(name = "created_at")
@@ -61,5 +53,5 @@ abstract class AuditableUuidEntity : AuditableEntity, Persistable<String> {
     override var archivedAt: Instant? = null
 
     override fun getId(): String? = id
-    override fun isNew(): Boolean = id == null
+    override fun isNew(): Boolean = !::createdAt.isInitialized
 }

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/AbstractEntity.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/AbstractEntity.kt
@@ -35,12 +35,19 @@ abstract class AuditableLongIdEntity : AuditableEntity, Persistable<Long> {
     override fun isNew(): Boolean = !::createdAt.isInitialized
 }
 
+@Converter(autoApply = true)
+class UuidToStringConverter : AttributeConverter<UUID, String> {
+    override fun convertToDatabaseColumn(attribute: UUID?): String? = attribute?.toString()
+    override fun convertToEntityAttribute(dbData: String?): UUID? = dbData?.let { UUID.fromString(it) }
+}
+
 @MappedSuperclass
 abstract class AuditableUuidEntity : AuditableEntity, Persistable<String> {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(name = "id", columnDefinition = "uuid")
-    private var id: UUID? = null
+    @Convert(converter = UuidToStringConverter::class)
+    private var id: String? = null
 
     @CreatedDate
     @Column(name = "created_at")
@@ -53,6 +60,6 @@ abstract class AuditableUuidEntity : AuditableEntity, Persistable<String> {
     @Column(name = "archived_at")
     override var archivedAt: Instant? = null
 
-    override fun getId(): String? = id?.toString()
+    override fun getId(): String? = id
     override fun isNew(): Boolean = id == null
 }

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateMember.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateMember.kt
@@ -38,4 +38,10 @@ interface DebateMemberRepository : JpaRepository<DebateMemberEntity, Long> {
     fun countByDebateForUpdate(debate: DebateEntity): Int
 
     fun findAllByDebateOrderByCreatedAtAsc(debate: DebateEntity): List<DebateMemberEntity>
+    fun existsByDebateAndAccount(debate: DebateEntity, account: AccountEntity): Boolean
+    fun existsByDebateIdAndAccountIdAndRole(
+        debateId: String,
+        accountId: String,
+        role: DebateMemberRole
+    ): Boolean
 }

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateRound.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateRound.kt
@@ -1,0 +1,37 @@
+package kr.co.booktalk.domain
+
+import jakarta.persistence.*
+import kr.co.booktalk.AuditableLongIdEntity
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Entity
+@Table(name = "debate_round")
+@EntityListeners(AuditingEntityListener::class)
+class DebateRoundEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "debate_id", nullable = false)
+    val debate: DebateEntity,
+
+    @Enumerated(EnumType.STRING)
+    val type: DebateRoundType,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_speaker_id")
+    var nextSpeaker: AccountEntity? = null,
+
+    var endedAt: Instant? = null
+) : AuditableLongIdEntity()
+
+enum class DebateRoundType {
+    PRESENTATION, FREE
+}
+
+@Transactional(readOnly = true)
+@Repository
+interface DebateRoundRepository : JpaRepository<DebateRoundEntity, Long> {
+    fun findByDebateAndEndedAtIsNull(debate: DebateEntity): DebateRoundEntity?
+}

--- a/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateRoundSpeaker.kt
+++ b/book-talk-be/data/src/main/kotlin/kr/co/booktalk/domain/DebateRoundSpeaker.kt
@@ -1,0 +1,31 @@
+package kr.co.booktalk.domain
+
+import jakarta.persistence.*
+import kr.co.booktalk.AuditableLongIdEntity
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Entity
+@Table(name = "debate_round_speaker")
+@EntityListeners(AuditingEntityListener::class)
+class DebateRoundSpeakerEntity(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "debate_round_id", nullable = false)
+    val debateRound: DebateRoundEntity,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    val account: AccountEntity,
+
+    @Column(nullable = false)
+    var endedAt: Instant,
+) : AuditableLongIdEntity()
+
+@Transactional(readOnly = true)
+@Repository
+interface DebateRoundSpeakerRepository : JpaRepository<DebateRoundSpeakerEntity, Long> {
+    fun findByDebateRoundAndEndedAtIsAfter(currentRound: DebateRoundEntity, now: Instant): DebateRoundSpeakerEntity?
+}

--- a/book-talk-be/data/src/main/resources/init/init-app-config.sql
+++ b/book-talk-be/data/src/main/resources/init/init-app-config.sql
@@ -1,3 +1,4 @@
 INSERT INTO app_config (key, value, cache_seconds)
 VALUES ('joinDebateDeadlineSeconds', '3600', 60),
-       ('maxDebateMemberCnt', '4', 60);
+       ('maxDebateMemberCnt', '4', 60),
+       ('debateRoundSpeakerSeconds', '90', 60);

--- a/book-talk-be/data/src/main/resources/schema/3.debate.sql
+++ b/book-talk-be/data/src/main/resources/schema/3.debate.sql
@@ -24,4 +24,29 @@ create table if not exists debate_member
     created_at  timestamp   not null,
     updated_at  timestamp   not null,
     archived_at timestamp   null
-)
+);
+
+create table if not exists debate_round
+(
+    id              bigint      not null primary key,
+    debate_id       uuid        not null,
+    type            varchar(20) not null, -- PRESENTATION, FREE
+    next_speaker_id uuid        null,
+    ended_at        timestamp   null,
+
+    created_at      timestamp   not null,
+    updated_at      timestamp   not null,
+    archived_at     timestamp   null
+);
+
+create table if not exists debate_round_speaker
+(
+    id              bigint    not null primary key,
+    debate_round_id bigint    not null,
+    account_id      uuid      not null,
+    ended_at        timestamp not null,
+
+    created_at      timestamp not null,
+    updated_at      timestamp not null,
+    archived_at     timestamp null
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 토론 라운드 생성/수정 및 라운드 발언자 생성/수정 API 추가(호스트 전용).
  - 토론 상세 조회에 현재 라운드 정보와 현재 발언자 표시.
  - 라운드 발언 시간 기본값(90초) 적용 및 연장/종료 처리 지원.

- 버그 수정
  - 토론 활성화 검증 로직 마감 처리 및 요청 파라미터 유효성 검증 보강.

- 작업
  - 초기 설정값에 라운드 발언 시간 추가.
  - 데이터베이스에 토론 라운드 및 라운드 발언자 테이블 신규 도입.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->