### PR TITLE
feat: add my account api

### DIFF
--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/AccountController.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/AccountController.kt
@@ -1,0 +1,17 @@
+package kr.co.booktalk.domain.account
+
+import kr.co.booktalk.ApiResult
+import kr.co.booktalk.domain.auth.AuthAccount
+import kr.co.booktalk.toResult
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AccountController(
+    private val accountService: AccountService
+) {
+    @GetMapping("/accounts/me")
+    fun findMy(authAccount: AuthAccount): ApiResult<FindMyResponse> {
+        return accountService.findMy(authAccount).toResult()
+    }
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/AccountService.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/AccountService.kt
@@ -2,7 +2,9 @@ package kr.co.booktalk.domain.account
 
 import kr.co.booktalk.domain.AccountEntity
 import kr.co.booktalk.domain.AccountRepository
+import kr.co.booktalk.domain.auth.AuthAccount
 import kr.co.booktalk.httpBadRequest
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,7 +15,7 @@ class AccountService(
         if (accountRepository.existsByName(request.name)) {
             httpBadRequest("이미 존재하는 계정입니다.")
         }
-        
+
         return accountRepository.save(
             AccountEntity(
                 name = request.name
@@ -23,5 +25,9 @@ class AccountService(
 
     fun findByName(name: String): AccountEntity {
         return accountRepository.findByName(name) ?: httpBadRequest("존재하지 않는 계정입니다.")
+    }
+
+    fun findMy(authAccount: AuthAccount): FindMyResponse {
+        return accountRepository.findByIdOrNull(authAccount.id)?.toResponse() ?: httpBadRequest("존재하지 않는 계정입니다.")
     }
 }

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/_Converters.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/_Converters.kt
@@ -1,0 +1,11 @@
+package kr.co.booktalk.domain.account
+
+import kr.co.booktalk.domain.AccountEntity
+
+fun AccountEntity.toResponse(): FindMyResponse {
+    return FindMyResponse(
+        id = id!!,
+        name = name,
+        createdAt = createdAt
+    )
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/_Responses.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/domain/account/_Responses.kt
@@ -1,0 +1,9 @@
+package kr.co.booktalk.domain.account
+
+import java.time.Instant
+
+data class FindMyResponse(
+    val id: String,
+    val name: String,
+    val createdAt: Instant,
+)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 인증 사용자용 “내 계정 조회” 엔드포인트 추가. 이제 /accounts/me 호출로 본인 계정의 ID, 이름, 생성일시를 확인할 수 있습니다.
  - 계정이 존재하지 않는 경우 요청을 명확한 오류 응답으로 처리하여 사용자 피드백을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->