### PR TITLE
feat: apply cors setting

### DIFF
--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/AppProperties.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/AppProperties.kt
@@ -1,0 +1,12 @@
+package kr.co.booktalk.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app")
+data class AppProperties(
+    val cors: CorsProperties = CorsProperties(),
+) {
+    data class CorsProperties(
+        val allowedOrigins: List<String> = emptyList(),
+    )
+}

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/PropertiesConfig.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/PropertiesConfig.kt
@@ -6,5 +6,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @EnableConfigurationProperties(
     LibProperties::class,
+    AppProperties::class,
 )
 class PropertiesConfig

--- a/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/WebConfig.kt
+++ b/book-talk-be/api/src/main/kotlin/kr/co/booktalk/config/WebConfig.kt
@@ -3,12 +3,23 @@ package kr.co.booktalk.config
 import kr.co.booktalk.domain.auth.AuthAccountArgumentResolver
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.method.support.HandlerMethodArgumentResolver
+import org.springframework.web.servlet.config.annotation.CorsRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 @Configuration
 class WebConfig(
+    private val appProperties: AppProperties,
     private val authAccountArgumentResolver: AuthAccountArgumentResolver,
 ) : WebMvcConfigurer {
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOriginPatterns(*appProperties.cors.allowedOrigins.toTypedArray())
+            .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+            .allowedHeaders("*")
+            .allowCredentials(true)
+            .maxAge(3600)
+    }
+
     override fun addArgumentResolvers(argumentResolvers: MutableList<HandlerMethodArgumentResolver>) {
         argumentResolvers.add(authAccountArgumentResolver)
     }

--- a/book-talk-be/api/src/main/resources/application.yml
+++ b/book-talk-be/api/src/main/resources/application.yml
@@ -13,3 +13,8 @@ spring:
     import:
       - classpath:application-data.yml
       - classpath:application-lib.yml
+
+app:
+  cors:
+    allowed-origins:
+      - ${APP_CORS_ALLOWED_ORIGINS}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 전역 CORS 구성 도입으로 웹 클라이언트에서 API 접근 정책을 세밀하게 제어합니다.
  - 허용 오리진을 환경 변수(APP_CORS_ALLOWED_ORIGINS)로 설정 가능하며, 자격 증명(쿠키/헤더) 포함 요청을 지원합니다.
  - GET/POST/PUT/DELETE/OPTIONS/PATCH 및 모든 헤더 허용으로 다양한 통신 시나리오를 지원합니다.

- 작업
  - 애플리케이션 구성에 app.* 네임스페이스를 추가해 환경별 설정 관리성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->